### PR TITLE
[R4R] middleware for verifying eth account

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/gin-gonic/gin"
+
+	"spike-blockchain-server/serializer"
+)
+
+func EthSignatureVerify() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var params ethParams
+		if err := c.ShouldBind(&params); err == nil {
+			if params.verify() {
+				c.Next()
+			} else {
+				c.JSON(200, serializer.Response{
+					Code:  101,
+					Error: "Invalid signature",
+				})
+			}
+		} else {
+			c.JSON(200, serializer.Response{
+				Code:  100,
+				Error: err.Error(),
+			})
+			c.Abort()
+		}
+	}
+}
+
+type ethParams struct {
+	Chain string `form:"chain" binding:"required"`
+	Sign  string `form:"sign"  binding:"required"`
+	Nonce string `form:"nonce" binding:"required"`
+	Addr  string `form:"addr"  binding:"required"`
+}
+
+func (params *ethParams) verify() bool {
+	sig := hexutil.MustDecode(params.Sign)
+	msg := accounts.TextHash([]byte(params.Nonce))
+	sig[crypto.RecoveryIDOffset] -= 27
+
+	recovered, err := crypto.SigToPub(msg, sig)
+	if err != nil {
+		return false
+	}
+	recoveredAddr := crypto.PubkeyToAddress(*recovered)
+	return strings.ToLower(params.Addr) == strings.ToLower(recoveredAddr.String())
+}

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestETHParamsVerify(t *testing.T) {
+	params := ethParams{
+		Chain: "eth",
+		Sign:  "0x64e34ad9914a2decc48ee445aea6ad6155789a6f1b912048500a81f5bbbb4411721ea559cc18fab0758d35918dfae1aa4adec41805a87caa11e817f1698d76681c",
+		Nonce: "hello, spike",
+		Addr:  "0x43a0D6FcD600f061B38e80D6580Ab900Ed67dFF1",
+	}
+	fmt.Println("ETH params.verify:", params.verify())
+}


### PR DESCRIPTION
By verifying eth account, server could send a token like jwt to client, so client could use the token without signing in.