### PR TITLE
Ipfs service

### DIFF
--- a/model/meta_data.go
+++ b/model/meta_data.go
@@ -1,0 +1,44 @@
+package model
+
+import "errors"
+
+type SpikeMetaData struct {
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Image       string       `json:"image"`
+	ExternalURL string       `json:"external_url"`
+	SpikeInfo   SpikeInfo    `json:"spike_info"`
+	Attributes  []Attributes `json:"attributes"`
+}
+
+type SpikeInfo struct {
+	Version        string `json:"version"`
+	SpikeModelURL  string `json:"spike_model_url"`
+	SpikeModelType string `json:"spike_model_type"`
+}
+
+type Attributes struct {
+	TraitType string `json:"trait_type"`
+	Value     string `json:"value"`
+}
+
+func (service *SpikeMetaData) ValidateMetaData() error {
+	if len(service.Name) == 0 || len(service.Name) >= 10 {
+		return errors.New("metadata name is Illegal")
+	}
+
+	if len(service.Description) == 0 {
+		return errors.New("Description cannot be empty ")
+	}
+
+	if len(service.SpikeInfo.SpikeModelType) == 0 || len(service.SpikeInfo.Version) == 0 || len(service.SpikeInfo.SpikeModelURL) == 0 {
+		return errors.New("SpikeInfo cannot be empty ")
+	}
+
+	for _, attribute := range service.Attributes {
+		if len(attribute.Value) == 0 || len(attribute.TraitType) == 0 {
+			return errors.New("attributes is Illegal")
+		}
+	}
+	return nil
+}

--- a/service/ipfs/create_metadata_service.go
+++ b/service/ipfs/create_metadata_service.go
@@ -1,0 +1,34 @@
+package ipfs
+
+import (
+	"encoding/json"
+	"spike-blockchain-server/model"
+	"spike-blockchain-server/serializer"
+)
+
+type CreateMetaDataService struct {
+	MetaJson []byte
+}
+
+func (service *CreateMetaDataService) CreateMetaData() serializer.Response {
+	metaData := model.SpikeMetaData{}
+	err := json.Unmarshal(service.MetaJson, &metaData)
+	if err != nil {
+		return serializer.Response{
+			Code:  400,
+			Error: err.Error(),
+		}
+	}
+	err = metaData.ValidateMetaData()
+	if err != nil {
+		return serializer.Response{
+			Code:  401,
+			Error: err.Error(),
+		}
+	}
+
+	return serializer.Response{
+		Code: 200,
+		Data: string(service.MetaJson),
+	}
+}

--- a/service/ipfs/create_metadata_service_test.go
+++ b/service/ipfs/create_metadata_service_test.go
@@ -1,0 +1,14 @@
+package ipfs
+
+import (
+	"github.com/joho/godotenv"
+	"testing"
+)
+
+func init() {
+	godotenv.Load("../../.env")
+}
+
+func TestCreateMetaData(t *testing.T) {
+
+}

--- a/service/ipfs/pin_file_service.go
+++ b/service/ipfs/pin_file_service.go
@@ -3,7 +3,6 @@ package ipfs
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/go-resty/resty/v2"
@@ -13,7 +12,7 @@ import (
 )
 
 type PinFileService struct {
-	Filepath string `json:"filepath"`
+	File []byte `json:"file"`
 }
 
 func (service *PinFileService) PinFile() serializer.Response {
@@ -34,19 +33,11 @@ func (service *PinFileService) PinFile() serializer.Response {
 		}
 	}
 
-	f, err := ioutil.ReadFile(service.Filepath)
-	if err != nil {
-		return serializer.Response{
-			Code:  402,
-			Error: err.Error(),
-		}
-	}
-
 	client := resty.New()
 	resp, err := client.R().
 		SetHeader("pinata_api_key", os.Getenv("PINATA_API_KEY")).
 		SetHeader("pinata_secret_api_key", os.Getenv("PINATA_SECRET_KEY")).
-		SetFileReader("file", ".env.example", bytes.NewReader(f)).
+		SetFileReader("file", ".env.example", bytes.NewReader(service.File)).
 		SetFormData(map[string]string{
 			"pinataOptions":  string(options),
 			"pinataMetadata": string(metadata),


### PR DESCRIPTION
1. fix pinFile : The files to be uploaded are not local in the service, but at the remote end.
2. feature  CreateMetaData :  This repository wants to provide all the functions related to blockchain, so the processing of MetaData is necessary, because we don't want other services to deal with the logic about blockchain, and we also don't trust other services' processing of blockchain information.